### PR TITLE
Updates package.engine field to remove install warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/suggest-it.js",
   "scripts": { "test": "tap test/*.js" },
   "engines": {
-    "node": "~0.6.9"
+    "node": "<=0.12.7"
   },
   "dependencies": {},
   "devDependencies": { "tap": "~0.2.3" },


### PR DESCRIPTION
Downstream dependant projects would get a warning when installing. e.g. `npm WARN engine suggest-it@0.0.1: wanted: {"node":"~0.6.9"} (current: {"node":"0.12.4","npm":"2.12.1"})`.
